### PR TITLE
Update top display after saving routine

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -51,6 +51,7 @@ saveModalSaveBtn.addEventListener('click', () => {
   if (loadSelect) loadSelect.value = name;
   updateDeleteButtonState();
   showToast(`Saved "${name}"`);
+  updateTopDisplay(state);
 });
 saveModalCancelBtn.addEventListener('click', () => closeSaveModal());
 // Confirm modal keyboard support
@@ -87,6 +88,7 @@ document.addEventListener('keydown', (e) => {
     if (loadSelect) loadSelect.value = name;
     updateDeleteButtonState();
     showToast(`Saved "${name}"`);
+    updateTopDisplay(state);
   }
 });
 


### PR DESCRIPTION
## Summary
- Update top display after saving a routine so the newly saved name appears
- Apply update for both button click and Enter key save paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc969232c832297590535cec55295