### PR TITLE
Add skip control to advance timers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ A lightweight, browser-based interval timer for building and running simple rout
 - Multiple timers: add, name, set duration (mm:ss), choose chime (10 included).
 - Repeats per timer: set how many times a timer repeats (1–99). While running, the active row shows current/total (e.g., 2/5); hidden when repeats = 1.
 - Drag-and-drop reorder with a handle for precise control.
-- Play/pause and stop controls with clear icons.
+- Play/pause, skip, and stop controls with clear icons.
 - Progress bars: per-timer and overall routine with completion checkmarks.
 - Local persistence: save routines to `localStorage`; auto-load last used routine.
 - Accessible modals for Save and Delete with keyboard support (Enter/Escape).
@@ -27,7 +27,7 @@ Option 2: Serve locally (recommended)
 - Add timer: click the “+” button.
 - Edit: set repeats (x) before the name, set a name, minutes and seconds, and pick a chime.
 - Reorder: drag using the ≡ handle on the left.
-- Run: press ▶ to start; press ⏸ to pause; press ⏹ to stop and reset.
+- Run: press ▶ to start; press ⏸ to pause; press ⏩ to skip the current timer; press ⏹ to stop and reset.
 - Save: click the disk icon, name your routine, then Save.
 - Load: use the dropdown to select a saved routine.
 - Delete: select a routine and click the trash icon; confirm in the modal.

--- a/src/dom.js
+++ b/src/dom.js
@@ -21,6 +21,14 @@ const toggleRoutineBtn = document.createElement('button');
 toggleRoutineBtn.id = 'toggle-routine';
 toggleRoutineBtn.className = 'btn btn--icon btn--primary';
 
+const skipRoutineBtn = document.createElement('button');
+skipRoutineBtn.textContent = '\u23E9'; // Fast-forward icon ⏩
+skipRoutineBtn.id = 'skip-timer';
+skipRoutineBtn.className = 'btn btn--icon btn--secondary';
+skipRoutineBtn.setAttribute('aria-label', 'Skip');
+skipRoutineBtn.title = 'Skip';
+skipRoutineBtn.style.display = 'none';
+
 const stopRoutineBtn = document.createElement('button');
 stopRoutineBtn.textContent = '\u23F9'; // Stop icon ⏹
 stopRoutineBtn.id = 'stop-routine';
@@ -29,6 +37,7 @@ stopRoutineBtn.setAttribute('aria-label', 'Stop');
 stopRoutineBtn.title = 'Stop';
 
 controlsContainer.appendChild(toggleRoutineBtn);
+controlsContainer.appendChild(skipRoutineBtn);
 controlsContainer.appendChild(stopRoutineBtn);
 
 export function updateToggleButton({ isRunning, isPaused }) {
@@ -36,6 +45,7 @@ export function updateToggleButton({ isRunning, isPaused }) {
   toggleRoutineBtn.textContent = (!isRunning || isPaused) ? '\u25B6' : '\u23F8';
   // Disable adding timers while routine is running (paused or not)
   if (addTimerBtn) addTimerBtn.disabled = !!isRunning;
+  if (skipRoutineBtn) skipRoutineBtn.style.display = isRunning ? '' : 'none';
 }
 
 export {
@@ -45,6 +55,7 @@ export {
   topDisplay,
   controlsContainer,
   toggleRoutineBtn,
+  skipRoutineBtn,
   stopRoutineBtn,
   audioEl,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 import state from './state.js';
-import { addTimerBtn, routineForm, toggleRoutineBtn, stopRoutineBtn, openSaveModal, closeSaveModal, saveModalNameInput, saveModalSaveBtn, saveModalCancelBtn, saveModal, showToast, openConfirmModal, closeConfirmModal, confirmModal, confirmModalConfirmBtn, confirmModalCancelBtn } from './dom.js';
+import { addTimerBtn, routineForm, toggleRoutineBtn, skipRoutineBtn, stopRoutineBtn, openSaveModal, closeSaveModal, saveModalNameInput, saveModalSaveBtn, saveModalCancelBtn, saveModal, showToast, openConfirmModal, closeConfirmModal, confirmModal, confirmModalConfirmBtn, confirmModalCancelBtn } from './dom.js';
 import { updateTopDisplay } from './ui/topDisplay.js';
 import { updateToggleButton } from './dom.js';
 import { renderTimers } from './timersList.js';
-import { stopRoutineIfRunning, togglePlayPause, stopRoutine } from './runner.js';
+import { stopRoutineIfRunning, togglePlayPause, stopRoutine, skipCurrentTimer } from './runner.js';
 import { saveRoutine, loadRoutine, listRoutines, deleteRoutine, getLastUsedRoutine, setLastUsedRoutine } from './storage.js';
 
 function autoSave() {
@@ -28,6 +28,10 @@ addTimerBtn.addEventListener('click', () => {
 // Controls
 toggleRoutineBtn.addEventListener('click', () => {
   togglePlayPause();
+});
+
+skipRoutineBtn.addEventListener('click', () => {
+  skipCurrentTimer();
 });
 
 stopRoutineBtn.addEventListener('click', () => {

--- a/src/runner.js
+++ b/src/runner.js
@@ -81,6 +81,16 @@ export function togglePlayPause() {
   updateToggleButton(state);
 }
 
+export function skipCurrentTimer() {
+  if (!state.isRunning) return;
+  const remaining = Math.max(0, state.timeLeft || 0);
+  state.routineElapsed += remaining;
+  clearInterval(state.timerInterval);
+  state.currentTimerIndex++;
+  state.currentRepeat = 1;
+  runRoutine();
+}
+
 export function stopRoutine() {
   // Always reset the routine, even if not currently running
   clearInterval(state.timerInterval);


### PR DESCRIPTION
## Summary
- add skip button with fast-forward icon to controls
- allow skipping to next timer without playing chime
- document skip control in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c557c390248322ba3f3b6c551a7f77